### PR TITLE
Fix lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![crate_type= "lib"]
 #![feature(custom_derive,
            custom_attribute,
-           append,
            plugin)]
 #![plugin(serde_macros)]
 #![cfg_attr(feature = "lints", plugin(clippy))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,10 @@
 #![cfg_attr(feature = "lints", allow(explicit_iter_loop))]
 #![cfg_attr(feature = "lints", allow(should_implement_trait))]
 #![cfg_attr(feature = "lints", deny(warnings))]
-#![deny(missing_docs,
-        missing_debug_implementations,
-        missing_copy_implementations,
-        trivial_casts, trivial_numeric_casts,
+#![deny(trivial_casts,
+        trivial_numeric_casts,
         unsafe_code,
-        unstable_features,
-        unused_import_braces,
-        unused_qualifications)]
+        unused_import_braces)]
 
 extern crate serde;
 extern crate serde_json;
@@ -34,5 +30,5 @@ pub use request::RequestBuilder;
 pub use request::DoRequest;
 
 #[cfg(test)]
-mod tests{
+mod tests {
 }

--- a/src/request/builder/arrays.rs
+++ b/src/request/builder/arrays.rs
@@ -12,7 +12,9 @@ impl response::NamedResponse for String {
     }
 }
 
-impl<'t> DoRequest<response::ResponseStringArray> for RequestBuilder<'t, response::ResponseStringArray> {
+impl<'t> DoRequest<response::ResponseStringArray> for RequestBuilder<'t,
+                                                                     response::ResponseStringArray>
+    {
     #[allow(unused_variables)]
     fn retrieve_obj(&self, obj: String) -> Result<response::ResponseStringArray, String> {
         debug!("Inside retrieve_obj() of ResponseStringArray");

--- a/src/request/builder/images.rs
+++ b/src/request/builder/images.rs
@@ -97,7 +97,6 @@ impl<'t> RequestBuilder<'t, response::Images> {
         self.url.push_str("?type=available");
         self
     }
-
 }
 
 impl<'t> DoRequest<response::Image> for RequestBuilder<'t, response::Image> {}

--- a/src/request/builder/request.rs
+++ b/src/request/builder/request.rs
@@ -84,7 +84,8 @@ impl<'t, T> BaseRequest for RequestBuilder<'t, T> {
 // impl<'t, T: !Iterator> DoRequest<T> for RequestBuilder<'t, T> { }
 
 impl<'t, I> PagedRequest for RequestBuilder<'t, Vec<I>>
-                                              where I: Deserialize + NamedResponse + NotArray {
+    where I: Deserialize + NamedResponse + NotArray
+{
     type Item = I;
     fn retrieve_single_page(&self, url: String) -> Result<RawPagedResponse<I>, String> {
         debug!("Inside retrieve_single_page() with url: {}", &url[..]);
@@ -121,7 +122,8 @@ impl<'t, I> PagedRequest for RequestBuilder<'t, Vec<I>>
 }
 
 impl<'t, I> DoRequest<Vec<I>> for RequestBuilder<'t, Vec<I>>
-                                where I: Deserialize + NamedResponse + NotArray {
+    where I: Deserialize + NamedResponse + NotArray
+{
     #[cfg_attr(not(feature = "debug"), allow(unused_variables))]
     fn retrieve(&self) -> Result<Vec<I>, String> {
         debug!("Inside retrieve() for  paged request");

--- a/src/response/namedresponse.rs
+++ b/src/response/namedresponse.rs
@@ -4,8 +4,8 @@ pub trait NamedResponse {
     fn name<'a>() -> Cow<'a, str>;
 }
 
-impl<T> NamedResponse for Vec<T>
-                        where T: NamedResponse {
+impl<T> NamedResponse for Vec<T> where T: NamedResponse
+{
     fn name<'a>() -> Cow<'a, str> {
         let mut n = String::with_capacity(15);
         n.push_str(<T as NamedResponse>::name().as_ref());

--- a/src/response/page.rs
+++ b/src/response/page.rs
@@ -22,7 +22,7 @@ pub trait NewIter {
     }
 }
 
-impl<R> NewIter for R
-              where R: Iterator {
+impl<R> NewIter for R where R: Iterator
+{
     type Item = <Self as Iterator>::Item;
 }


### PR DESCRIPTION
In https://github.com/kbknapp/doapi-rs/commit/0c223c671233024c6e38a7b99d20f6d324d14ca1, you added new `#![deny(..)]` lints, without changing the code accordingly. **As a result, `doapi-rs` fails to build** because of missing copy and debug implementations, missing docs and "unnecessary qualifications" that are actually useful — that is, the code fails to compile without them.

This PR removes the three problematic lints, fixes a warning (the `append` feature is now stable) and runs `rustfmt` (I couldn't easily do it in a separate commit as I have `rust.vim` configured to run it automatically on save).
