### PR TITLE
Permit an absent content-type

### DIFF
--- a/src/response/header.rs
+++ b/src/response/header.rs
@@ -31,8 +31,8 @@ impl response::NotArray for HeaderOnly {}
 impl HeaderOnly {
     pub fn from_response(r: Response) -> Result<HeaderOnly, String> {
         let c_type = match r.headers.get::<header::ContentType>() {
-            Some(c) => c,
-            None => return Err("No content-type provided".to_owned()),
+            Some(c) => c.to_string(),
+            None => String::new(),
         };
         let raw_status = r.status_raw();
         let status = format!("{} {}", raw_status.0, raw_status.1);
@@ -64,7 +64,7 @@ impl HeaderOnly {
             Err(e) => return Err(e.to_string()),
         };
         Ok(HeaderOnly {
-            content_type: c_type.to_string(),
+            content_type: c_type,
             status: status,
             ratelimit_limit: rl_limit,
             ratelimit_remaining: rl_remain,


### PR DESCRIPTION
Despite what the DO docs say for deleting a droplet (https://developers.digitalocean.com/documentation/v2/#delete-a-droplet), it does not appear to return with any content type (which is valid).

I think the better way to handle this would be to make content-type an Option and bump the version of doapi-rs due to the backwards incompatibility - let me know if you're ok with this and I'll alter this PR.
