### PR TITLE
Update Cargo.toml to match version on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "doapi"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Kevin K. <kbknapp@gmail.com>"]
 description = "A wrapper library for the DigitalOcean API v2"
 license = "MIT"


### PR DESCRIPTION
(wasn't bumped when 0.1.3 was released)
